### PR TITLE
Fix mismatch parenthesis and typo

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -27,7 +27,7 @@ const UserSchema = new Schema({
     type: Number,
     required: true
   },
-  marraige: {
+  marriage: {
     type: Number,
     required: true
   },

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -39,7 +39,7 @@ router.post('/register', (req, res) => {
 
       //use bcrypt to genereate our salt
       //bcrypt.genSalt(10(number of times to generate salt, callbackfunction(err, salt) ))
-      bcrypt.genSalt(10, (err, salt => {
+      bcrypt.genSalt(10, (err, salt) => {
         bcrypt.hash(newUser.password, salt, (err, hash) => {
           if (err) throw err;
           newUser.password = hash;
@@ -48,7 +48,7 @@ router.post('/register', (req, res) => {
             .then((user) => res.send(user))
             .catch(err => console.log(err))
         })
-      }))
+      })
     }
   })
 })


### PR DESCRIPTION
I was testing the user's register method and there was a mismatch in parenthesis in the bcrypt's callback that was erroring out. I've also been using my own mongoose db for testing, so we don't necessarily all have to use Ara's. If we do share a database under Ara, I suggest she make a different user for all of us, so we can all have a different user under her db. 

we don't need to have a dedicated database till production though, for now, we can all test on our own databases. 